### PR TITLE
Get all invoices

### DIFF
--- a/chargebee_byte/client.py
+++ b/chargebee_byte/client.py
@@ -1,7 +1,7 @@
 import requests
 from copy import deepcopy
 
-from chargebee_byte.requests import SubscriptionRequest, CustomerRequest
+from chargebee_byte.requests import SubscriptionRequest, CustomerRequest, InvoiceRequest
 
 
 class Client(object):
@@ -37,3 +37,6 @@ class Client(object):
 
     def get_all_customers(self, parameters=None):
         return self._get_all_objects(self.get_paginated_customers, parameters)
+
+    def get_paginated_invoices(self, parameters=None):
+        return self._get_paginated_objects(InvoiceRequest(parameters))

--- a/chargebee_byte/client.py
+++ b/chargebee_byte/client.py
@@ -40,3 +40,6 @@ class Client(object):
 
     def get_paginated_invoices(self, parameters=None):
         return self._get_paginated_objects(InvoiceRequest(parameters))
+
+    def get_all_invoices(self, parameters=None):
+        return self._get_all_objects(self.get_paginated_invoices, parameters)

--- a/chargebee_byte/requests.py
+++ b/chargebee_byte/requests.py
@@ -59,3 +59,27 @@ class CustomerRequest(ChargebeeRequest):
         params += generate_parameters(['id'], ['starts_with'])
 
         return ['limit', 'offset', 'include_deleted'] + params
+
+
+class InvoiceRequest(ChargebeeRequest):
+    path = '/invoices'
+
+    def generate_allowed_parameters(self):
+        params = generate_sorting_parameters(['sort_by'])
+        params += generate_equals_parameters(['id', 'subscription_id', 'customer_id', 'status', 'price_type', 'total',
+                                              'amount_paid', 'amount_adjusted', 'credits_applied', 'amount_due',
+                                              'dunning_status', 'payment_owner', 'void_reason_code'])
+        params += generate_collection_parameters(['id', 'subscription_id', 'customer_id', 'status', 'price_type',
+                                                  'dunning_status', 'payment_owner', 'void_reason_code'])
+        params += generate_date_parameters(['date', 'paid_at', 'updated_at', 'voided_at'])
+        params += generate_comparison_parameters(['total', 'amount_paid', 'amount_adjusted', 'credits_applied',
+                                                  'amount_due'])
+        params += generate_parameters(['id', 'subscription_id', 'customer_id', 'payment_owner', 'void_reason_code'],
+                                      ['starts_with'])
+        params += generate_parameters(['subscription_id', 'dunning_status'], ['is_present'])
+        params += generate_parameters(['recurring'], ['is'])
+        params += generate_parameters(['total', 'amount_paid', 'amount_adjusted', 'credits_applied',
+                                       'amount_due'], ['between'])
+
+        return ['limit', 'offset', 'include_deleted'] + params
+

--- a/chargebee_byte/requests.py
+++ b/chargebee_byte/requests.py
@@ -82,4 +82,3 @@ class InvoiceRequest(ChargebeeRequest):
                                        'amount_due'], ['between'])
 
         return ['limit', 'offset', 'include_deleted'] + params
-

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(dirname(abspath(__file__)))
 
 setuptools.setup(
     name='chargebee-byte',
-    version='0.1.2',
+    version='0.1.3',
     license='MIT',
     description='Chargebee API library. Made by Byte.nl',
     long_description=open('README.md').read(),

--- a/tests/client/test_get_all_customers.py
+++ b/tests/client/test_get_all_customers.py
@@ -18,10 +18,10 @@ class TestGetAllCustomers(TestBase):
         self.assertNotIn(parameter, CustomerRequest().allowed_parameters)
 
         with self.assertRaises(ValueError):
-            self.chargebee_client.get_all_subscriptions(parameters={parameter: 'bonobo'})
+            self.chargebee_client.get_all_customers(parameters={parameter: 'bonobo'})
 
     def test_calls_raise_for_status_on_requests_response(self):
-        self.chargebee_client.get_all_subscriptions()
+        self.chargebee_client.get_all_customers()
 
         self.response.raise_for_status.assert_called_once_with()
 

--- a/tests/client/test_get_all_invoices.py
+++ b/tests/client/test_get_all_invoices.py
@@ -1,0 +1,123 @@
+from unittest import mock
+
+from chargebee_byte.requests import InvoiceRequest
+from tests.test import TestBase
+
+
+class TestGetAllInvoices(TestBase):
+    def setUp(self):
+        super().setUp()
+        self.requests_get = self.set_up_patch('chargebee_byte.client.requests.get')
+
+        self.response = mock.Mock()
+        self.response.json.return_value = {'list': []}
+        self.requests_get.return_value = self.response
+
+    def test_raises_value_error_if_unknown_parameter_supplied(self):
+        parameter = 'banaan[henk]'
+        self.assertNotIn(parameter, InvoiceRequest().allowed_parameters)
+
+        with self.assertRaises(ValueError):
+            self.chargebee_client.get_all_invoices(parameters={parameter: 'bonobo'})
+
+    def test_calls_raise_for_status_on_requests_response(self):
+        self.chargebee_client.get_all_invoices()
+
+        self.response.raise_for_status.assert_called_once_with()
+
+    def test_keeps_querying_chargebee_if_next_offset_returned(self):
+        response_1 = mock.Mock()
+        response_1.json.return_value = {
+            'list': [],
+            'next_offset': '["1522747277000", "1522747277010"]'
+        }
+        response_2 = mock.Mock()
+        response_2.json.return_value = {
+            'list': [],
+            'next_offset': '["1522747277010", "1522747277020"]'
+        }
+        response_3 = mock.Mock()
+        response_3.json.return_value = {
+            'list': [],
+        }
+        self.requests_get.side_effect = [response_1, response_2, response_3]
+
+        self.chargebee_client.get_all_invoices()
+
+        self.requests_get.assert_has_calls([
+            mock.call(
+                self.chargebee_client.api_url + '/invoices',
+                auth=self.chargebee_client.auth,
+                params={'offset': ''}
+            ),
+            mock.call(
+                self.chargebee_client.api_url + '/invoices',
+                auth=self.chargebee_client.auth,
+                params={'offset': '["1522747277000", "1522747277010"]'}
+            ),
+            mock.call(
+                self.chargebee_client.api_url + '/invoices',
+                auth=self.chargebee_client.auth,
+                params={'offset': '["1522747277010", "1522747277020"]'}
+            ),
+        ])
+
+    def test_returns_all_invoices(self):
+        response_1 = mock.Mock()
+        response_1.json.return_value = {
+            'list': [{'invoice': {'id': 1}}],
+            'next_offset': '["1522747277000", "1522747277010"]'
+        }
+        response_2 = mock.Mock()
+        response_2.json.return_value = {
+            'list': [{'invoice': {'id': 2}}],
+            'next_offset': '["1522747277010", "1522747277020"]'
+        }
+        response_3 = mock.Mock()
+        response_3.json.return_value = {
+            'list': [{'invoice': {'id': 3}}],
+        }
+        self.requests_get.side_effect = [response_1, response_2, response_3]
+
+        ret = self.chargebee_client.get_all_invoices()
+
+        self.assertCountEqual(ret, [{'invoice': {'id': 1}},
+                                    {'invoice': {'id': 2}},
+                                    {'invoice': {'id': 3}}])
+
+    def test_preserves_parameters_when_doing_multiple_requests_to_chargebee(self):
+        response_1 = mock.Mock()
+        response_1.json.return_value = {
+            'list': [],
+            'next_offset': '["1522747277000", "1522747277010"]'
+        }
+        response_2 = mock.Mock()
+        response_2.json.return_value = {
+            'list': [],
+            'next_offset': '["1522747277010", "1522747277020"]'
+        }
+        response_3 = mock.Mock()
+        response_3.json.return_value = {
+            'list': [],
+        }
+        self.requests_get.side_effect = [response_1, response_2, response_3]
+
+        self.chargebee_client.get_all_invoices({'sort_by[asc]': 'first_name'})
+
+        self.requests_get.assert_has_calls([
+            mock.call(
+                self.chargebee_client.api_url + '/invoices',
+                auth=self.chargebee_client.auth,
+                params={'sort_by[asc]': 'first_name', 'offset': ''}
+            ),
+            mock.call(
+                self.chargebee_client.api_url + '/invoices',
+                auth=self.chargebee_client.auth,
+                params={'sort_by[asc]': 'first_name', 'offset': '["1522747277000", "1522747277010"]'}
+            ),
+            mock.call(
+                self.chargebee_client.api_url + '/invoices',
+                auth=self.chargebee_client.auth,
+                params={'sort_by[asc]': 'first_name', 'offset': '["1522747277010", "1522747277020"]'}
+            ),
+        ])

--- a/tests/client/test_get_paginated_customers.py
+++ b/tests/client/test_get_paginated_customers.py
@@ -17,6 +17,7 @@ class TestGetPaginatedCustomers(TestBase):
 
         self.get_paginated_objects.assert_called_once_with(self.customer_request({}))
 
+    def test_returns_get_paginated_objects_return_value(self):
+        ret = self.chargebee_client.get_paginated_invoices()
 
-
-
+        self.assertEqual(ret, self.get_paginated_objects.return_value)

--- a/tests/client/test_get_paginated_invoices.py
+++ b/tests/client/test_get_paginated_invoices.py
@@ -21,7 +21,3 @@ class TestGetPaginatedInvoices(TestBase):
         ret = self.chargebee_client.get_paginated_invoices()
 
         self.assertEqual(ret, self.get_paginated_objects.return_value)
-
-
-
-

--- a/tests/client/test_get_paginated_invoices.py
+++ b/tests/client/test_get_paginated_invoices.py
@@ -1,0 +1,27 @@
+from tests.test import TestBase
+
+
+class TestGetPaginatedInvoices(TestBase):
+    def setUp(self):
+        super(TestGetPaginatedInvoices, self).setUp()
+        self.get_paginated_objects = self.set_up_patch('chargebee_byte.client.Client._get_paginated_objects')
+        self.invoice_request = self.set_up_patch('chargebee_byte.client.InvoiceRequest')
+
+    def test_calls_get_paginated_objects_with_correct_parameters(self):
+        self.chargebee_client.get_paginated_invoices(parameters={'sort_by[asc]': 'first_name'})
+
+        self.get_paginated_objects.assert_called_once_with(self.invoice_request({'sort_by[asc]': 'first_name'}))
+
+    def test_calls_get_paginated_objects_with_empty_parameters(self):
+        self.chargebee_client.get_paginated_invoices()
+
+        self.get_paginated_objects.assert_called_once_with(self.invoice_request({}))
+
+    def test_returns_get_paginated_objects_return_value(self):
+        ret = self.chargebee_client.get_paginated_invoices()
+
+        self.assertEqual(ret, self.get_paginated_objects.return_value)
+
+
+
+

--- a/tests/client/test_get_paginated_subscriptions.py
+++ b/tests/client/test_get_paginated_subscriptions.py
@@ -16,3 +16,8 @@ class TestGetPaginatedSubscriptions(TestBase):
         self.chargebee_client.get_paginated_subscriptions()
 
         self.get_paginated_objects.assert_called_once_with(self.subscription_request({}))
+
+    def test_returns_get_paginated_objects_return_value(self):
+        ret = self.chargebee_client.get_paginated_invoices()
+
+        self.assertEqual(ret, self.get_paginated_objects.return_value)

--- a/tests/requests/test_invoice_request.py
+++ b/tests/requests/test_invoice_request.py
@@ -1,0 +1,135 @@
+from unittest import TestCase
+
+from chargebee_byte.requests import ChargebeeRequest, InvoiceRequest
+
+
+class TestInvoiceRequest(TestCase):
+    maxDiff = None
+
+    def setUp(self):
+        self.request = InvoiceRequest()
+
+    def test_inherits_from_chargebee_request(self):
+        self.assertIsInstance(self.request, ChargebeeRequest)
+
+    def test_path_is_set_to_subscriptions(self):
+        self.assertEqual(self.request.path, '/invoices')
+
+    def test_has_correct_allowed_params_set(self):
+        self.assertCountEqual(self.request.allowed_parameters, [
+            'limit',
+            'offset',
+            'include_deleted',
+
+            'id[is]',
+            'id[is_not]',
+            'id[in]',
+            'id[not_in]',
+            'id[starts_with]',
+
+            'subscription_id[is]',
+            'subscription_id[is_not]',
+            'subscription_id[in]',
+            'subscription_id[not_in]',
+            'subscription_id[starts_with]',
+            'subscription_id[is_present]',
+
+            'customer_id[is]',
+            'customer_id[is_not]',
+            'customer_id[in]',
+            'customer_id[not_in]',
+            'customer_id[starts_with]',
+
+            'status[is]',
+            'status[is_not]',
+            'status[in]',
+            'status[not_in]',
+
+            'price_type[is]',
+            'price_type[is_not]',
+            'price_type[in]',
+            'price_type[not_in]',
+
+            'total[is]',
+            'total[is_not]',
+            'total[lt]',
+            'total[lte]',
+            'total[gt]',
+            'total[gte]',
+            'total[between]',
+
+            'amount_paid[is]',
+            'amount_paid[is_not]',
+            'amount_paid[lt]',
+            'amount_paid[lte]',
+            'amount_paid[gt]',
+            'amount_paid[gte]',
+            'amount_paid[between]',
+
+            'amount_adjusted[is]',
+            'amount_adjusted[is_not]',
+            'amount_adjusted[lt]',
+            'amount_adjusted[lte]',
+            'amount_adjusted[gt]',
+            'amount_adjusted[gte]',
+            'amount_adjusted[between]',
+
+            'credits_applied[is]',
+            'credits_applied[is_not]',
+            'credits_applied[lt]',
+            'credits_applied[lte]',
+            'credits_applied[gt]',
+            'credits_applied[gte]',
+            'credits_applied[between]',
+
+            'amount_due[is]',
+            'amount_due[is_not]',
+            'amount_due[lt]',
+            'amount_due[lte]',
+            'amount_due[gt]',
+            'amount_due[gte]',
+            'amount_due[between]',
+
+            'dunning_status[is]',
+            'dunning_status[is_not]',
+            'dunning_status[in]',
+            'dunning_status[not_in]',
+            'dunning_status[is_present]',
+
+            'payment_owner[is]',
+            'payment_owner[is_not]',
+            'payment_owner[in]',
+            'payment_owner[not_in]',
+            'payment_owner[starts_with]',
+
+            'void_reason_code[is]',
+            'void_reason_code[is_not]',
+            'void_reason_code[in]',
+            'void_reason_code[not_in]',
+            'void_reason_code[starts_with]',
+
+            'date[after]',
+            'date[before]',
+            'date[on]',
+            'date[between]',
+
+            'paid_at[after]',
+            'paid_at[before]',
+            'paid_at[on]',
+            'paid_at[between]',
+
+            'updated_at[after]',
+            'updated_at[before]',
+            'updated_at[on]',
+            'updated_at[between]',
+
+            'voided_at[after]',
+            'voided_at[before]',
+            'voided_at[on]',
+            'voided_at[between]',
+
+            'sort_by[asc]',
+            'sort_by[desc]',
+
+            'recurring[is]',
+        ])


### PR DESCRIPTION
Add `get_all_invoices` functionality so we can easily retrieve all invoices without having to keep querying chargebee ourselves.