### PR TITLE
Limit API calls to chargebee

### DIFF
--- a/chargebee_byte/client.py
+++ b/chargebee_byte/client.py
@@ -28,6 +28,7 @@ class Client(object):
 
         while 'next_offset' in ret:
             new_parameters = deepcopy(parameters) or {}
+            new_parameters['limit'] = 100
             new_parameters['offset'] = ret['next_offset']
             ret = paginated_func(new_parameters)
             objects += ret['list']

--- a/chargebee_byte/client.py
+++ b/chargebee_byte/client.py
@@ -1,3 +1,6 @@
+import time
+from datetime import datetime, timedelta
+
 import requests
 from copy import deepcopy
 
@@ -5,11 +8,16 @@ from chargebee_byte.requests import SubscriptionRequest, CustomerRequest, Invoic
 
 
 class Client(object):
-    def __init__(self, site, api_key):
+    def __init__(self, site, api_key, rate_limit=None):
         self.auth = requests.auth.HTTPBasicAuth(api_key, '')
         self.api_url = 'https://{}.chargebee.com/api/v2'.format(site)
+        self.rate_limit = rate_limit
+        self.last_request = None
 
     def _get_paginated_objects(self, request):
+        if self.rate_limit and self.last_request and (self.last_request + timedelta(0, self.rate_limit)) > datetime.now():
+            time.sleep(self.rate_limit)
+        self.last_request = datetime.now()
         response = requests.get(self.api_url + request.path, auth=self.auth, params=request.data)
         response.raise_for_status()
         return response.json()

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,3 +2,4 @@
 nose2
 pylint
 pycodestyle
+libfaketime==2.0.0

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(dirname(abspath(__file__)))
 
 setuptools.setup(
     name='chargebee-byte',
-    version='0.1.3',
+    version='0.1.4',
     license='MIT',
     description='Chargebee API library. Made by Byte.nl',
     long_description=open('README.md').read(),

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -1,5 +1,6 @@
 import requests
 
+from chargebee_byte.client import Client
 from tests.test import TestBase
 
 
@@ -9,3 +10,11 @@ class TestClient(TestBase):
 
     def test_sets_auth_to_http_basic_auth_method_with_api_key_as_username(self):
         self.assertEqual(self.chargebee_client.auth, requests.auth.HTTPBasicAuth('my_api_key', ''))
+
+    def test_sets_rate_limit_to_none_when_rate_limit_is_not_provided(self):
+        self.assertIsNone(self.chargebee_client.rate_limit)
+
+    def test_sets_rate_limit_to_provided_rate_limit(self):
+        self.chargebee_client = Client('my_site', 'my_api_key', rate_limit=10)
+
+        self.assertEqual(self.chargebee_client.rate_limit, 10)

--- a/tests/client/test_get_all_customers.py
+++ b/tests/client/test_get_all_customers.py
@@ -48,17 +48,17 @@ class TestGetAllCustomers(TestBase):
             mock.call(
                 self.chargebee_client.api_url + '/customers',
                 auth=self.chargebee_client.auth,
-                params={'offset': ''}
+                params={'offset': '', 'limit': 100}
             ),
             mock.call(
                 self.chargebee_client.api_url + '/customers',
                 auth=self.chargebee_client.auth,
-                params={'offset': '["1522747277000", "1522747277010"]'}
+                params={'offset': '["1522747277000", "1522747277010"]', 'limit': 100}
             ),
             mock.call(
                 self.chargebee_client.api_url + '/customers',
                 auth=self.chargebee_client.auth,
-                params={'offset': '["1522747277010", "1522747277020"]'}
+                params={'offset': '["1522747277010", "1522747277020"]', 'limit': 100}
             ),
         ])
 
@@ -108,16 +108,16 @@ class TestGetAllCustomers(TestBase):
             mock.call(
                 self.chargebee_client.api_url + '/customers',
                 auth=self.chargebee_client.auth,
-                params={'sort_by[asc]': 'first_name', 'offset': ''}
+                params={'sort_by[asc]': 'first_name', 'offset': '', 'limit': 100}
             ),
             mock.call(
                 self.chargebee_client.api_url + '/customers',
                 auth=self.chargebee_client.auth,
-                params={'sort_by[asc]': 'first_name', 'offset': '["1522747277000", "1522747277010"]'}
+                params={'sort_by[asc]': 'first_name', 'offset': '["1522747277000", "1522747277010"]', 'limit': 100}
             ),
             mock.call(
                 self.chargebee_client.api_url + '/customers',
                 auth=self.chargebee_client.auth,
-                params={'sort_by[asc]': 'first_name', 'offset': '["1522747277010", "1522747277020"]'}
+                params={'sort_by[asc]': 'first_name', 'offset': '["1522747277010", "1522747277020"]', 'limit': 100}
             ),
         ])

--- a/tests/client/test_get_all_invoices.py
+++ b/tests/client/test_get_all_invoices.py
@@ -48,17 +48,17 @@ class TestGetAllInvoices(TestBase):
             mock.call(
                 self.chargebee_client.api_url + '/invoices',
                 auth=self.chargebee_client.auth,
-                params={'offset': ''}
+                params={'offset': '', 'limit': 100}
             ),
             mock.call(
                 self.chargebee_client.api_url + '/invoices',
                 auth=self.chargebee_client.auth,
-                params={'offset': '["1522747277000", "1522747277010"]'}
+                params={'offset': '["1522747277000", "1522747277010"]', 'limit': 100}
             ),
             mock.call(
                 self.chargebee_client.api_url + '/invoices',
                 auth=self.chargebee_client.auth,
-                params={'offset': '["1522747277010", "1522747277020"]'}
+                params={'offset': '["1522747277010", "1522747277020"]', 'limit': 100}
             ),
         ])
 
@@ -108,16 +108,16 @@ class TestGetAllInvoices(TestBase):
             mock.call(
                 self.chargebee_client.api_url + '/invoices',
                 auth=self.chargebee_client.auth,
-                params={'sort_by[asc]': 'first_name', 'offset': ''}
+                params={'sort_by[asc]': 'first_name', 'offset': '', 'limit': 100}
             ),
             mock.call(
                 self.chargebee_client.api_url + '/invoices',
                 auth=self.chargebee_client.auth,
-                params={'sort_by[asc]': 'first_name', 'offset': '["1522747277000", "1522747277010"]'}
+                params={'sort_by[asc]': 'first_name', 'offset': '["1522747277000", "1522747277010"]', 'limit': 100}
             ),
             mock.call(
                 self.chargebee_client.api_url + '/invoices',
                 auth=self.chargebee_client.auth,
-                params={'sort_by[asc]': 'first_name', 'offset': '["1522747277010", "1522747277020"]'}
+                params={'sort_by[asc]': 'first_name', 'offset': '["1522747277010", "1522747277020"]', 'limit': 100}
             ),
         ])

--- a/tests/client/test_get_all_subscriptions.py
+++ b/tests/client/test_get_all_subscriptions.py
@@ -48,17 +48,17 @@ class TestGetAllSubscriptions(TestBase):
             mock.call(
                 self.chargebee_client.api_url + '/subscriptions',
                 auth=self.chargebee_client.auth,
-                params={'offset': ''}
+                params={'offset': '', 'limit': 100}
             ),
             mock.call(
                 self.chargebee_client.api_url + '/subscriptions',
                 auth=self.chargebee_client.auth,
-                params={'offset': '["1522747277000", "1522747277010"]'}
+                params={'offset': '["1522747277000", "1522747277010"]', 'limit': 100}
             ),
             mock.call(
                 self.chargebee_client.api_url + '/subscriptions',
                 auth=self.chargebee_client.auth,
-                params={'offset': '["1522747277010", "1522747277020"]'}
+                params={'offset': '["1522747277010", "1522747277020"]', 'limit': 100}
             ),
         ])
 
@@ -108,16 +108,16 @@ class TestGetAllSubscriptions(TestBase):
             mock.call(
                 self.chargebee_client.api_url + '/subscriptions',
                 auth=self.chargebee_client.auth,
-                params={'status[is]': 'active', 'offset': ''}
+                params={'status[is]': 'active', 'offset': '', 'limit': 100}
             ),
             mock.call(
                 self.chargebee_client.api_url + '/subscriptions',
                 auth=self.chargebee_client.auth,
-                params={'status[is]': 'active', 'offset': '["1522747277000", "1522747277010"]'}
+                params={'status[is]': 'active', 'offset': '["1522747277000", "1522747277010"]', 'limit': 100}
             ),
             mock.call(
                 self.chargebee_client.api_url + '/subscriptions',
                 auth=self.chargebee_client.auth,
-                params={'status[is]': 'active', 'offset': '["1522747277010", "1522747277020"]'}
+                params={'status[is]': 'active', 'offset': '["1522747277010", "1522747277020"]', 'limit': 100}
             ),
         ])

--- a/tests/client/test_get_paginated_objects.py
+++ b/tests/client/test_get_paginated_objects.py
@@ -1,5 +1,8 @@
+import datetime
 from unittest.mock import MagicMock
+from libfaketime import freeze_time
 
+from chargebee_byte.client import Client
 from tests.test import TestBase
 
 
@@ -7,6 +10,7 @@ class TestGetPaginatedObjects(TestBase):
     def setUp(self):
         super().setUp()
         self.requests_get = self.set_up_patch('chargebee_byte.client.requests.get')
+        self.mock_sleep = self.set_up_patch('chargebee_byte.client.time.sleep')
         self.request = MagicMock(path='/my_path', data={'sort_by[asc]': 'first_name'})
 
     def test_calls_chargebee_api_with_correct_parameters(self):
@@ -27,3 +31,23 @@ class TestGetPaginatedObjects(TestBase):
         self.chargebee_client._get_paginated_objects(self.request)
 
         self.requests_get.return_value.raise_for_status.assert_called_once_with()
+
+    @freeze_time('2021-01-01')
+    def test_calls_time_sleep_when_rate_limit_exists_and_last_request_plus_rate_limit_is_more_recent_than_now(self):
+        rate_limit_in_seconds = 5
+        self.chargebee_client = Client('my_site', 'my_api_key', rate_limit_in_seconds)
+        self.chargebee_client.last_request = datetime.datetime(2021, 1, 1, 0, 0, 6)
+
+        self.chargebee_client._get_paginated_objects(self.request)
+
+        self.mock_sleep.assert_called_once_with(rate_limit_in_seconds)
+
+    @freeze_time('2021-01-01')
+    def test_does_not_call_sleep_when_last_request_is_less_recent_than_now(self):
+        rate_limit_in_seconds = 5
+        self.chargebee_client = Client('my_site', 'my_api_key', rate_limit_in_seconds)
+        self.chargebee_client.last_request = datetime.datetime(2021, 1, 1, 0, 0, 1)
+
+        self.chargebee_client._get_paginated_objects(self.request)
+
+        self.mock_sleep.assert_not_called()


### PR DESCRIPTION
- Default call to chargebee has default parameter set to `10`. I default it to `100` on each `get_all` call. 
- Add the possibility to add `rate_limit` on the initialization of the connector.